### PR TITLE
Add code coverage data and Coveralls badge

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,2 +1,8 @@
 language: java
 
+cache:
+  directories:
+  - $HOME/.m2
+
+script:
+  - mvn clean cobertura:cobertura -Dcobertura.report.format=xml org.eluder.coveralls:coveralls-maven-plugin:report

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # IOU Core
 
 [![Travis CI](https://travis-ci.org/ioweyou/iou-core.svg)](https://travis-ci.org/ioweyou/iou-core)
-[![Coverage Status](https://coveralls.io/repos/github/rikvdbrule/iou-core/badge.svg?branch=master)](https://coveralls.io/github/rikvdbrule/iou-core?branch=master)
+[![Coverage Status](https://coveralls.io/repos/github/ioweyou/iou-core/badge.svg?branch=master)](https://coveralls.io/github/ioweyou/iou-core?branch=master)
 [![License MIT](https://img.shields.io/:license-mit-blue.svg)](http://badges.mit-license.org)
 
 Java promise-library that adheres to the [A+ spec](https://github.com/promises-aplus/promises-spec) as closely as possible. It designed to be extended by other libraries, like [IOU Java](https://github.com/ioweyou/iou-java) and [IOU Android](https://github.com/ioweyou/iou-android).

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # IOU Core
 
 [![Travis CI](https://travis-ci.org/ioweyou/iou-core.svg)](https://travis-ci.org/ioweyou/iou-core)
+[![Coverage Status](https://coveralls.io/repos/github/rikvdbrule/iou-core/badge.svg?branch=master)](https://coveralls.io/github/rikvdbrule/iou-core?branch=master)
 [![License MIT](https://img.shields.io/:license-mit-blue.svg)](http://badges.mit-license.org)
 
 Java promise-library that adheres to the [A+ spec](https://github.com/promises-aplus/promises-spec) as closely as possible. It designed to be extended by other libraries, like [IOU Java](https://github.com/ioweyou/iou-java) and [IOU Android](https://github.com/ioweyou/iou-android).

--- a/pom.xml
+++ b/pom.xml
@@ -117,6 +117,23 @@
                 </execution>
               </executions>
             </plugin>
+
+            <plugin>
+              <groupId>org.codehaus.mojo</groupId>
+              <artifactId>cobertura-maven-plugin</artifactId>
+              <version>2.7</version>
+              <configuration>
+                  <format>xml</format>
+                  <maxmem>256m</maxmem>
+                  <!-- aggregated reports for multi-module projects -->
+                  <aggregate>true</aggregate>
+              </configuration>
+            </plugin>
+            <plugin>
+              <groupId>org.eluder.coveralls</groupId>
+              <artifactId>coveralls-maven-plugin</artifactId>
+              <version>4.1.0</version>
+            </plugin>
         </plugins>
       </build>
     </profile>


### PR DESCRIPTION
Travis-CI generates a code coverage report which is submitted to Coveralls.
The coverall badge is displayed in README.md.

Travis-CI also configured to cache the maven dependencies, shaving off download time from the CI build.

You may need to enable Coveralls for the main repo at [Coveralls](coveralls.io). The badge link is branch-specific, so it will display `unknown` because the master branch badge is embedded.
